### PR TITLE
Build against asio-standalone included in link sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ CCFLAGS += -Wno-multichar
 CCFLAGS += -DLINK_PLATFORM_LINUX=1
 CCFLAGS += -Ilink/include
 
+CCFLAGS += -DASIO_STANDALONE=1
+CCFLAGS += -Ilink/modules/asio-standalone/asio/include
+
 LDFLAGS += -ljack -lpthread
 
 HEADERS  = jack_link.hpp

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@
 ## Prerequisites
 
    **jack_link** software prerequisites for building are a C++11 compiler
-   (_g++_), the [JACK](http://jackaudio.org) client C libraries and headers
-   (_libjack-devel_) and the [Asio C++ Library](http://think-async.com/Asio/)
-   for cross-platform network and low-level I/O (_asio-devel_).
+   (_g++_) and the [JACK](http://jackaudio.org) client C libraries and headers
+   (_libjack-devel_).
 
 
 ## Building


### PR DESCRIPTION
This skips the asio and boost dependencies, and we're able to build jack_link with just g++ and jack libs.
Also might be safer this way, as we'll be using an asio version that is known to work with link.